### PR TITLE
Contao 4.9 compatibility and improvement of error handling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
         },
         "require": {
             "contao/core-bundle": "^4.4",
-            "heimrichhannot/contao-multi-column-editor-bundle": "^1.0"
+            "heimrichhannot/contao-multi-column-editor-bundle": "^1.0",
+            "ext-ldap": "*"
         },
         "require-dev": {
             "symfony/debug-bundle": "^3.3 || ^4.0",

--- a/src/Resources/contao/classes/Backend/LdapPerson.php
+++ b/src/Resources/contao/classes/Backend/LdapPerson.php
@@ -21,7 +21,7 @@ class LdapPerson
     public function importPersonFromLdap($strUsername, $strPassword, $strTable)
     {
 		\System::getContainer()
-			->get('logger')
+			->get('monolog.logger.contao')
 			->info('Invoke '.__CLASS__.'::'.__FUNCTION__,
 				array('contao' => new ContaoContext(__CLASS__.'::'.__FUNCTION__, TL_GENERAL),
 					'strUsername' => $strUsername,
@@ -60,7 +60,7 @@ class LdapPerson
     public function authenticateAgainstLdap($strUsername, $strPassword, $objLocalPerson)
     {
 		\System::getContainer()
-			->get('logger')
+			->get('monolog.logger.contao')
 			->info('Invoke '.__CLASS__.'::'.__FUNCTION__,
 				array('contao' => new ContaoContext(__CLASS__.'::'.__FUNCTION__, TL_GENERAL),
 					'strUsername' => $strUsername,
@@ -96,7 +96,7 @@ class LdapPerson
     public static function authenticateLdapPerson($strUsername, $strPassword)
     {
 		\System::getContainer()
-			->get('logger')
+			->get('monolog.logger.contao')
 			->info('Invoke '.__CLASS__.'::'.__FUNCTION__,
 				array('contao' => new ContaoContext(__CLASS__.'::'.__FUNCTION__, TL_GENERAL),
 					'strUsername' => $strUsername,
@@ -120,7 +120,7 @@ class LdapPerson
 		} catch (\ErrorException $ee) {
 
             \System::getContainer()
-                ->get('logger')
+                ->get('monolog.logger.contao')
                 ->error(
                     'Exception '.__CLASS__.'::'.__FUNCTION__,
                     array('contao' => new ContaoContext(__CLASS__.'::'.__FUNCTION__, TL_GENERAL)));
@@ -137,7 +137,7 @@ class LdapPerson
     public static function updatePersons($arrSelectedLdapGroups) {
 
 		\System::getContainer()
-			->get('logger')
+			->get('monolog.logger.contao')
 			->info('Invoke '.__CLASS__.'::'.__FUNCTION__,
 				array('contao' => new ContaoContext(__CLASS__.'::'.__FUNCTION__, TL_GENERAL),
 					'arrSelectedLdapGroups' => $arrSelectedLdapGroups));
@@ -264,7 +264,7 @@ class LdapPerson
     public static function updatePerson($objLocalPerson, $arrLdapPerson, $arrSelectedLdapGroups)
     {        
 		\System::getContainer()
-			->get('logger')
+			->get('monolog.logger.contao')
 			->info('Invoke '.__CLASS__.'::'.__FUNCTION__,
 				array('contao' => new ContaoContext(__CLASS__.'::'.__FUNCTION__, TL_GENERAL),
 					'objLocalPerson' => $objLocalPerson,
@@ -294,7 +294,7 @@ class LdapPerson
     public static function applyFieldMapping($objPerson, $arrRemoteLdapPerson)
     {
 		\System::getContainer()
-			->get('logger')
+			->get('monolog.logger.contao')
 			->info('Invoke '.__CLASS__.'::'.__FUNCTION__,
 				array('contao' => new ContaoContext(__CLASS__.'::'.__FUNCTION__, TL_GENERAL),
 					'objPerson' => $objPerson,
@@ -335,7 +335,7 @@ class LdapPerson
     private static function getLdapField($arrRemoteLdapPerson, $strLdapField)
     {
 		\System::getContainer()
-			->get('logger')
+			->get('monolog.logger.contao')
 			->info('Invoke '.__CLASS__.'::'.__FUNCTION__,
 				array('contao' => new ContaoContext(__CLASS__.'::'.__FUNCTION__, TL_GENERAL),
 					'arrRemoteLdapPerson' => $arrRemoteLdapPerson,
@@ -371,7 +371,7 @@ class LdapPerson
     public static function applyDefaultValues($objPerson)
     {
 		\System::getContainer()
-			->get('logger')
+			->get('monolog.logger.contao')
 			->info('Invoke '.__CLASS__.'::'.__FUNCTION__,
 				array('contao' => new ContaoContext(__CLASS__.'::'.__FUNCTION__, TL_GENERAL),
 					'objPerson' => $objPerson));
@@ -393,7 +393,7 @@ class LdapPerson
     public static function updateAssignedGroups($objLocalPerson, $arrSelectedLdapGroups) {
 
 		\System::getContainer()
-			->get('logger')
+			->get('monolog.logger.contao')
 			->info('Invoke '.__CLASS__.'::'.__FUNCTION__,
 				array('contao' => new ContaoContext(__CLASS__.'::'.__FUNCTION__, TL_GENERAL),
 					'objPerson' => $objLocalPerson,

--- a/src/Resources/contao/classes/Backend/LdapPersonGroup.php
+++ b/src/Resources/contao/classes/Backend/LdapPersonGroup.php
@@ -27,7 +27,7 @@ class LdapPersonGroup
     public static function getLdapGroupsAsOptions()
     {
 		\System::getContainer()
-			->get('logger')
+			->get('monolog.logger.contao')
 			->info('Invoke '.__CLASS__.'::'.__FUNCTION__,
 				array('contao' => new ContaoContext(__CLASS__.'::'.__FUNCTION__, TL_GENERAL)));
 
@@ -49,7 +49,7 @@ class LdapPersonGroup
         asort($arrGroups);
 
 		\System::getContainer()
-			->get('logger')
+			->get('monolog.logger.contao')
 			->info('Result '.__CLASS__.'::'.__FUNCTION__,
 				array('contao' => new ContaoContext(__CLASS__.'::'.__FUNCTION__, TL_GENERAL),
 					'arrGroups' => $arrGroups));
@@ -69,7 +69,7 @@ class LdapPersonGroup
 	public static function storeSettings($varValue) {
 
 		\System::getContainer()
-			->get('logger')
+			->get('monolog.logger.contao')
 			->info('Invoke '.__CLASS__.'::'.__FUNCTION__,
 				array('contao' => new ContaoContext(__CLASS__.'::'.__FUNCTION__, TL_GENERAL),
 					'varValue' => $varValue));
@@ -99,7 +99,7 @@ class LdapPersonGroup
 		$ldapPersonClass::updatePersons($arrSelectedLdapGroups);
 
 		\System::getContainer()
-			->get('logger')
+			->get('monolog.logger.contao')
 			->info('Result '.__CLASS__.'::'.__FUNCTION__,
 				array('contao' => new ContaoContext(__CLASS__.'::'.__FUNCTION__, TL_GENERAL),
 					'varValue' => $varValue));
@@ -116,7 +116,7 @@ class LdapPersonGroup
     public static function loadPersonGroups($value, $container) {
 
 		\System::getContainer()
-			->get('logger')
+			->get('monolog.logger.contao')
 			->info('Invoke '.__CLASS__.'::'.__FUNCTION__,
 				array('contao' => new ContaoContext(__CLASS__.'::'.__FUNCTION__, TL_GENERAL),
 					'value' => $value,
@@ -137,7 +137,7 @@ class LdapPersonGroup
 		}
 
 		\System::getContainer()
-			->get('logger')
+			->get('monolog.logger.contao')
 			->info('Result '.__CLASS__.'::'.__FUNCTION__,
 				array('contao' => new ContaoContext(__CLASS__.'::'.__FUNCTION__, TL_GENERAL),
 					'value' => $value));
@@ -164,7 +164,7 @@ class LdapPersonGroup
     public static function updateGroups($arrSelectedLdapGroups = []) {
 
 		\System::getContainer()
-			->get('logger')
+			->get('monolog.logger.contao')
 			->info('Invoke '.__CLASS__.'::'.__FUNCTION__,
 				array('contao' => new ContaoContext(__CLASS__.'::'.__FUNCTION__, TL_GENERAL),
 					'arrSelectedLdapGroups' => $arrSelectedLdapGroups));

--- a/src/Resources/contao/dca/tl_settings.php
+++ b/src/Resources/contao/dca/tl_settings.php
@@ -42,6 +42,7 @@ $arrFields = [
         'inputType' => 'text',
         'default'   => 389,
         'eval'      => ['mandatory' => true, 'maxlength' => 5, 'rgxp' => 'digit', 'tl_class' => 'w50'],
+        'load_callback' => [['DefaultHandler', 'getDefaultValue']],
     ],
     'binddn'              => [
         'label'     => &$GLOBALS['TL_LANG']['tl_settings']['binddn'],
@@ -62,6 +63,7 @@ $arrFields = [
         'inputType' => 'select',
         'options'   => ['ssl'],
         'eval'      => ['tl_class' => 'w50', 'includeBlankOption' => true],
+        'load_callback' => [['DefaultHandler', 'getDefaultValue']],
     ],
     'personBase'          => [
         'label'     => &$GLOBALS['TL_LANG']['tl_settings']['personBase'],
@@ -90,6 +92,7 @@ $arrFields = [
         'inputType' => 'text',
         'default'   => 'uniqueMember',
         'eval'      => ['mandatory' => true, 'maxlength' => 64, 'tl_class' => 'w50'],
+        'load_callback' => [['DefaultHandler', 'getDefaultValue']],
     ],
     'skipLdapUsernames'   => [
         'label'     => &$GLOBALS['TL_LANG']['tl_settings']['skipLdapUsernames'],

--- a/src/Resources/contao/dca/tl_settings.php
+++ b/src/Resources/contao/dca/tl_settings.php
@@ -84,6 +84,13 @@ $arrFields = [
         'default'   => 'uid',
         'eval'      => ['mandatory' => true, 'maxlength' => 64, 'tl_class' => 'w50'],
     ],
+    'ldapGroupMemberField'   => [
+        'label'     => &$GLOBALS['TL_LANG']['tl_settings']['ldapGroupMemberField'],
+        'exclude'   => true,
+        'inputType' => 'text',
+        'default'   => 'uniqueMember',
+        'eval'      => ['mandatory' => true, 'maxlength' => 64, 'tl_class' => 'w50'],
+    ],
     'skipLdapUsernames'   => [
         'label'     => &$GLOBALS['TL_LANG']['tl_settings']['skipLdapUsernames'],
         'exclude'   => true,

--- a/src/Resources/contao/languages/de/tl_settings.php
+++ b/src/Resources/contao/languages/de/tl_settings.php
@@ -36,6 +36,7 @@ $arrLang['binddn']              = [
     'Bind DN',
     'Suchfilter für den Benutzer, der für die Anmeldung am Server genutzt werden soll (Beispiel: CN=ldapadmin,CN=users,DC=sampledomain,DC=com; bei ActiveDirectories kann auch <Domain>\<User> genutzt werden.).'
 ];
+$arrLang['ldapGroupMemberField']= ['LDAP-Gruppenmitgliederfeld', 'Name des Attributs, welches Mitglieder einer Gruppe kennzeichnet (Standard: uniqueMember).'];
 $arrLang['password']            = ['Bind DN Passwort', 'Geben Sie das Passwort für den Bind DN-Benutzer an.'];
 $arrLang['groups']              = ['Zu importierende Gruppen', 'Legen Sie fest, welche LDAP-Mitgliedergruppen verfügbar sein sollen.'];
 $arrLang['skipLdapUsernames']   = [

--- a/src/Resources/contao/languages/en/tl_settings.php
+++ b/src/Resources/contao/languages/en/tl_settings.php
@@ -36,6 +36,7 @@ $arrLang['binddn']              = [
     'Bind user DN',
     'Distinguished name of the LDAP user used to bind to the LDAP server (e.g. cn=ldapadmin,cn=users,dc=domain,dc=com; for AD &lt;Domain&gt;\&lt;User&gt; can be used).'
 ];
+$arrLang['ldapGroupMemberField']= ['LDAP group member key', 'Name ot the attribute used for members of a group (defaults: uniqueMember).'];
 $arrLang['password']            = ['Bind user password', 'Enter the password for the bind user.'];
 $arrLang['groups']              = ['Groups to import', 'Define which LDAP member groups should be available.'];
 $arrLang['skipLdapUsernames']   = [

--- a/src/Resources/contao/models/LdapPersonGroupModel.php
+++ b/src/Resources/contao/models/LdapPersonGroupModel.php
@@ -60,9 +60,10 @@ abstract class LdapPersonGroupModel extends \Model
                     ->get('monolog.logger.contao')
                     ->error('Exception occurred on LDAP search '.__CLASS__.'::'.__FUNCTION__,
                         array('contao' => new ContaoContext(__CLASS__.'::'.__FUNCTION__, TL_GENERAL),
-                            'error' => $ee));
+                            'error' => $ee,
+                            'filter' => $strFilter));
 
-                \Message::addError('Exception occurred on LDAP search');
+                \Message::addError('Exception occurred on LDAP search: ' . $ee->getMessage());
                 return false;
             }
 

--- a/src/Resources/contao/models/LdapPersonGroupModel.php
+++ b/src/Resources/contao/models/LdapPersonGroupModel.php
@@ -56,16 +56,18 @@ abstract class LdapPersonGroupModel extends \Model
                     static::$arrRequiredAttributes
                 );
             } catch (\ErrorException $ee) {
+                \System::getContainer()
+                    ->get('monolog.logger.contao')
+                    ->error('Exception occurred on LDAP search '.__CLASS__.'::'.__FUNCTION__,
+                        array('contao' => new ContaoContext(__CLASS__.'::'.__FUNCTION__, TL_GENERAL),
+                            'error' => $ee));
 
-                // TODO die...
-                die('Ex: ldap search failed ('.__CLASS__.'::'.__FUNCTION__.')');
+                \Message::addError('Exception occurred on LDAP search');
                 return false;
             }
 
             if (!$strQuery) {
-
-                // TODO die...
-            	die('ldap query failed');
+                \Message::addError('LDAP query failed');
                 return false;
             }
 

--- a/src/Resources/contao/models/LdapPersonGroupModel.php
+++ b/src/Resources/contao/models/LdapPersonGroupModel.php
@@ -22,7 +22,7 @@ abstract class LdapPersonGroupModel extends \Model
     public static function findAll(array $arrOptions = [])
     { 
 		\System::getContainer()
-			->get('logger')
+			->get('monolog.logger.contao')
 			->info('Invoke '.__CLASS__.'::'.__FUNCTION__,
 				array('contao' => new ContaoContext(__CLASS__.'::'.__FUNCTION__, TL_GENERAL),
 					'arrOptions' => $arrOptions));
@@ -94,7 +94,7 @@ abstract class LdapPersonGroupModel extends \Model
             }
 
 			\System::getContainer()
-				->get('logger')
+				->get('monolog.logger.contao')
 				->info('Result '.__CLASS__.'::'.__FUNCTION__,
 					array('contao' => new ContaoContext(__CLASS__.'::'.__FUNCTION__, TL_GENERAL),
 						'arrGroups' => $arrGroups));
@@ -137,7 +137,7 @@ abstract class LdapPersonGroupModel extends \Model
             true);
     
 		\System::getContainer()
-			->get('logger')
+			->get('monolog.logger.contao')
 			->info('Result '.__CLASS__.'::'.__FUNCTION__,
 				array('contao' => new ContaoContext(__CLASS__.'::'.__FUNCTION__, TL_GENERAL),
 					'arrSelectedLdapGroups' => $arrSelectedLdapGroups));
@@ -154,7 +154,7 @@ abstract class LdapPersonGroupModel extends \Model
     public static function getLocalLdapGroupIds($arrRemoteLdapGroupDNs)
     {
 		\System::getContainer()
-			->get('logger')
+			->get('monolog.logger.contao')
 			->info('Invoke '.__CLASS__.'::'.__FUNCTION__,
 				array('contao' => new ContaoContext(__CLASS__.'::'.__FUNCTION__, TL_GENERAL),
 					'arrRemoteLdapGroupDNs' => $arrRemoteLdapGroupDNs));
@@ -172,7 +172,7 @@ abstract class LdapPersonGroupModel extends \Model
         }
 
 		\System::getContainer()
-			->get('logger')
+			->get('monolog.logger.contao')
 			->info('Result '.__CLASS__.'::'.__FUNCTION__,
 				array('contao' => new ContaoContext(__CLASS__.'::'.__FUNCTION__, TL_GENERAL),
 					'arrResult' => $arrResult));

--- a/src/Resources/contao/models/LdapPersonModel.php
+++ b/src/Resources/contao/models/LdapPersonModel.php
@@ -54,9 +54,13 @@ abstract class LdapPersonModel extends \Model
                     $arrAttributes
                 );
             } catch (\ErrorException $ee) {
+                \System::getContainer()
+                    ->get('monolog.logger.contao')
+                    ->error('Exception occurred on LDAP search '.__CLASS__.'::'.__FUNCTION__,
+                        array('contao' => new ContaoContext(__CLASS__.'::'.__FUNCTION__, TL_GENERAL),
+                            'error' => $ee));
 
-                // TODO die...
-                die( 'Ex: ldap search failed ('.__CLASS__.'::'.__FUNCTION__.')' );
+                \Message::addError('LDAP search failed');
                 return false;
             }
 
@@ -183,14 +187,18 @@ abstract class LdapPersonModel extends \Model
                     $arrAttributes);
 
             } catch (\ErrorException $ee) {
+                \System::getContainer()
+                    ->get('monolog.logger.contao')
+                    ->error('Exception occurred on LDAP search '.__CLASS__.'::'.__FUNCTION__,
+                        array('contao' => new ContaoContext(__CLASS__.'::'.__FUNCTION__, TL_GENERAL),
+                            'error' => $ee));
 
-                // TODO die...
-                die('Ex: ldap search failed ('.__CLASS__.'::'.__FUNCTION__.')');
+                \Message::addError('LDAP search failed');
                 return false;
             }
 
             if (!$strQuery) {
-            	die('findByUsername: query failed');
+                \Message::addError('LDAP query failed');
                 return null;
             }
 

--- a/src/Resources/contao/models/LdapPersonModel.php
+++ b/src/Resources/contao/models/LdapPersonModel.php
@@ -58,9 +58,11 @@ abstract class LdapPersonModel extends \Model
                     ->get('monolog.logger.contao')
                     ->error('Exception occurred on LDAP search '.__CLASS__.'::'.__FUNCTION__,
                         array('contao' => new ContaoContext(__CLASS__.'::'.__FUNCTION__, TL_GENERAL),
-                            'error' => $ee));
+                            'error' => $ee,
+                            'filter' => $strFilter,
+                            'attributes' => $arrAttributes));
 
-                \Message::addError('LDAP search failed');
+                \Message::addError('LDAP search failed: ' . $ee->getMessage());
                 return false;
             }
 
@@ -191,9 +193,11 @@ abstract class LdapPersonModel extends \Model
                     ->get('monolog.logger.contao')
                     ->error('Exception occurred on LDAP search '.__CLASS__.'::'.__FUNCTION__,
                         array('contao' => new ContaoContext(__CLASS__.'::'.__FUNCTION__, TL_GENERAL),
-                            'error' => $ee));
+                            'error' => $ee,
+                            'filter' => $strFilter,
+                            'attributes' => $arrAttributes));
 
-                \Message::addError('LDAP search failed');
+                \Message::addError('LDAP search failed: ' . $ee->getMessage());
                 return false;
             }
 

--- a/src/Resources/contao/models/LdapPersonModel.php
+++ b/src/Resources/contao/models/LdapPersonModel.php
@@ -25,7 +25,7 @@ abstract class LdapPersonModel extends \Model
     public static function findAll(array $arrOptions = [])
     {
 		\System::getContainer()
-			->get('logger')
+			->get('monolog.logger.contao')
 			->info('Invoke '.__CLASS__.'::'.__FUNCTION__,
 				array('contao' => new ContaoContext(__CLASS__.'::'.__FUNCTION__, TL_GENERAL),
 					'arrOptions' => $arrOptions));
@@ -71,7 +71,7 @@ abstract class LdapPersonModel extends \Model
             }
 
 			\System::getContainer()
-				->get('logger')
+				->get('monolog.logger.contao')
 				->info('Result '.__CLASS__.'::'.__FUNCTION__,
 					array('contao' => new ContaoContext(__CLASS__.'::'.__FUNCTION__, TL_GENERAL), 
 						'arrResult' => $arrResult));
@@ -87,7 +87,7 @@ abstract class LdapPersonModel extends \Model
     /*public static function findByDn($strUserDN)
     {
 		\System::getContainer()
-			->get('logger')
+			->get('monolog.logger.contao')
 			->info('Invoke '.__CLASS__.'::'.__FUNCTION__,
 				array('contao' => new ContaoContext(__CLASS__.'::'.__FUNCTION__, TL_GENERAL),
 					'strUserDN' => $strUserDN));
@@ -117,7 +117,7 @@ abstract class LdapPersonModel extends \Model
             }
 
 			\System::getContainer()
-				->get('logger')
+				->get('monolog.logger.contao')
 				->info('Result[0] '.__CLASS__.'::'.__FUNCTION__,
 					array('contao' => new ContaoContext(__CLASS__.'::'.__FUNCTION__, TL_GENERAL),
 						'arrResult' => $arrResult));
@@ -148,7 +148,7 @@ abstract class LdapPersonModel extends \Model
     public static function findByUsername($strUsername)
     {
 		\System::getContainer()
-			->get('logger')
+			->get('monolog.logger.contao')
 			->info('Invoke '.__CLASS__.'::'.__FUNCTION__,
 				array('contao' => new ContaoContext(__CLASS__.'::'.__FUNCTION__, TL_GENERAL),
 					'strUsername' => $strUsername));
@@ -201,7 +201,7 @@ abstract class LdapPersonModel extends \Model
             }
 
 			\System::getContainer()
-				->get('logger')
+				->get('monolog.logger.contao')
 				->info('Result[0] '.__CLASS__.'::'.__FUNCTION__,
 					array('contao' => new ContaoContext(__CLASS__.'::'.__FUNCTION__, TL_GENERAL),
 						'arrResult' => $arrResult));
@@ -215,7 +215,7 @@ abstract class LdapPersonModel extends \Model
     private static function addAttributes($arrAttributes)
     {
 		\System::getContainer()
-			->get('logger')
+			->get('monolog.logger.contao')
 			->info('Invoke '.__CLASS__.'::'.__FUNCTION__,
 				array('contao' => new ContaoContext(__CLASS__.'::'.__FUNCTION__, TL_GENERAL),
 					'arrAttributes' => $arrAttributes));
@@ -235,7 +235,7 @@ abstract class LdapPersonModel extends \Model
         }
 
 		\System::getContainer()
-			->get('logger')
+			->get('monolog.logger.contao')
 			->info('Result '.__CLASS__.'::'.__FUNCTION__,
 				array('contao' => new ContaoContext(__CLASS__.'::'.__FUNCTION__, TL_GENERAL),
 					'arrAttributes' => $arrAttributes));
@@ -250,7 +250,7 @@ abstract class LdapPersonModel extends \Model
     public static function findAssignedGroups($strUserDN)
     {
 		\System::getContainer()
-			->get('logger')
+			->get('monolog.logger.contao')
 			->info('Invoke '.__CLASS__.'::'.__FUNCTION__,
 				array('contao' => new ContaoContext(__CLASS__.'::'.__FUNCTION__, TL_GENERAL),
                     'strUserDN' => $strUserDN));
@@ -277,7 +277,7 @@ abstract class LdapPersonModel extends \Model
         }
 
 		\System::getContainer()
-			->get('logger')
+			->get('monolog.logger.contao')
 			->info('Result '.__CLASS__.'::'.__FUNCTION__,
 				array('contao' => new ContaoContext(__CLASS__.'::'.__FUNCTION__, TL_GENERAL),
 					'arrGroups' => $arrGroups));


### PR DESCRIPTION
I just tried to modify the plugin to work with our current setup, I think those changes might be interesting for anyone.

Basically:
* Logging is changed to be compatible with Contao 4.9
* A new option for the identifier of group member is introduced, so that it can be changed
* Error handling is improved, the `die()` statements are removed